### PR TITLE
Allow only Arduino framework to be used

### DIFF
--- a/components/snmp/__init__.py
+++ b/components/snmp/__init__.py
@@ -19,6 +19,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional("location", default=""): cv.string_strict,
         }
     ),
+    cv.only_with_arduino,
 )
 
 


### PR DESCRIPTION
Used esphome config validation to check for supported platform.
