### PR TITLE
Removed USE_ARDUINO

### DIFF
--- a/components/snmp/snmp_component.cpp
+++ b/components/snmp/snmp_component.cpp
@@ -1,5 +1,3 @@
-#ifdef USE_ARDUINO
-
 #include "snmp_component.h"
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
@@ -314,5 +312,3 @@ int SNMPComponent::get_ram_size_kb() {
 
 }  // namespace snmp
 }  // namespace esphome
-
-#endif  // USE_ARDUINO

--- a/components/snmp/snmp_component.h
+++ b/components/snmp/snmp_component.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#ifdef USE_ARDUINO
-
 #include <string>
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
@@ -71,5 +69,3 @@ class SNMPComponent : public Component {
 
 }  // namespace snmp
 }  // namespace esphome
-
-#endif  // USE_ARDUINO


### PR DESCRIPTION
Removed USE_ARDUINO so that the ESPHome Configuration Validation will work as intended.