### PR TITLE
Adding variables for Community and Sensor

### DIFF
--- a/components/snmp/__init__.py
+++ b/components/snmp/__init__.py
@@ -2,10 +2,10 @@ from esphome.const import CONF_ID
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.core import CORE
+from esphome.components import sensor   # NEW
 
 CODEOWNERS = ["@aquaticus"]
 
-# No ethernet support at the moment
 DEPENDENCIES = ["wifi"]
 
 snmp_ns = cg.esphome_ns.namespace("snmp")
@@ -17,23 +17,32 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(SNMPComponent),
             cv.Optional("contact", default=""): cv.string_strict,
             cv.Optional("location", default=""): cv.string_strict,
-            cv.Optional('read_community', default='public'): cv.string,
-            cv.Optional('write_community', default='private'): cv.string,            
+            cv.Optional("read_community", default="public"): cv.string,
+            cv.Optional("write_community", default="private"): cv.string,
+            cv.Optional("temperature"): cv.use_id(sensor.Sensor),  # NEW
+            cv.Optional("humidity"): cv.use_id(sensor.Sensor),     # NEW
         }
     ),
     cv.only_with_arduino,
 )
-
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
     cg.add(var.set_location(config["location"]))
     cg.add(var.set_contact(config["contact"]))
-    cg.add(var.set_read_community(config['read_community']))
-    cg.add(var.set_write_community(config['write_community']))
+    cg.add(var.set_read_community(config["read_community"]))
+    cg.add(var.set_write_community(config["write_community"]))
 
     await cg.register_component(var, config)
+
+    if "temperature" in config:
+        sens = await cg.get_variable(config["temperature"])
+        cg.add(var.set_temperature_sensor(sens))
+
+    if "humidity" in config:
+        sens = await cg.get_variable(config["humidity"])
+        cg.add(var.set_humidity_sensor(sens))
 
     if CORE.is_esp8266 or CORE.is_esp32:
         cg.add_library(r"https://github.com/aquaticus/Arduino_SNMP.git", "2.1.0")

--- a/components/snmp/__init__.py
+++ b/components/snmp/__init__.py
@@ -17,6 +17,8 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(SNMPComponent),
             cv.Optional("contact", default=""): cv.string_strict,
             cv.Optional("location", default=""): cv.string_strict,
+            cv.Optional('read_community', default='public'): cv.string,
+            cv.Optional('write_community', default='private'): cv.string,            
         }
     ),
     cv.only_with_arduino,
@@ -28,6 +30,8 @@ async def to_code(config):
 
     cg.add(var.set_location(config["location"]))
     cg.add(var.set_contact(config["contact"]))
+    cg.add(var.set_read_community(config['read_community']))
+    cg.add(var.set_write_community(config['write_community']))
 
     await cg.register_component(var, config)
 

--- a/components/snmp/snmp_component.cpp
+++ b/components/snmp/snmp_component.cpp
@@ -13,107 +13,82 @@ namespace snmp {
 
 static const char *const TAG = "snmp";
 
-/// @brief Returns network uptime
-/// @return time in hundreds of seconds
-/// @warning 
-/// Function returns real value if @c wifi_connected_timestamp() function
-/// was implemented in WiFi module.
+// ---- NEW static instance pointer ----
+SNMPComponent *SNMPComponent::instance_ = nullptr;
+
 uint32_t SNMPComponent::get_net_uptime() {
 #ifdef WIFI_CONNECTED_TIMESTAMP_AVAILABLE
   return (millis() - wifi::global_wifi_component->wifi_connected_timestamp()) / 10;
 #else
-  return 0; //not available
+  return 0; // not available
 #endif
 }
 
+// ---- NEW static functions for SNMP callbacks ----
+int SNMPComponent::get_temperature() {
+  if (instance_ == nullptr || instance_->temperature_sensor_ == nullptr) return 0;
+  if (!instance_->temperature_sensor_->has_state()) return 0;
+  return static_cast<int>(instance_->temperature_sensor_->state * 10.0f);  // tenths
+}
+
+int SNMPComponent::get_humidity() {
+  if (instance_ == nullptr || instance_->humidity_sensor_ == nullptr) return 0;
+  if (!instance_->humidity_sensor_->has_state()) return 0;
+  return static_cast<int>(instance_->humidity_sensor_->state * 10.0f);  // tenths
+}
+
+
 void SNMPComponent::setup_system_mib_() {
-  // sysDesc
   const char *desc_fmt = "ESPHome version " ESPHOME_VERSION " compiled %s, Board " ESPHOME_BOARD;
   char description[128];
   snprintf(description, sizeof(description), desc_fmt, App.get_compilation_time().c_str());
   snmp_agent_.addReadOnlyStaticStringHandler(RFC1213_OID_sysDescr, description);
-
-  // sysName
   snmp_agent_.addDynamicReadOnlyStringHandler(RFC1213_OID_sysName, []() -> std::string { return App.get_name(); });
-
-  // sysServices
   snmp_agent_.addReadOnlyIntegerHandler(RFC1213_OID_sysServices, 64 /*=2^(7-1) applications*/);
-
-  // sysObjectID
   snmp_agent_.addOIDHandler(RFC1213_OID_sysObjectID,
 #ifdef USE_ESP32
-                            CUSTOM_OID "32"
+                           CUSTOM_OID "32"
 #else
-                            CUSTOM_OID "8266"
+                           CUSTOM_OID "8266"
 #endif
   );
-
-  // sysContact
-  snmp_agent_.addReadOnlyStaticStringHandler(RFC1213_OID_sysContact, contact_);
-
-  // sysLocation
-  snmp_agent_.addReadOnlyStaticStringHandler(RFC1213_OID_sysLocation, location_);
+  snmp_agent_.addReadOnlyStaticStringHandler(RFC1213_OID_sysContact, contact_.c_str());
+  snmp_agent_.addReadOnlyStaticStringHandler(RFC1213_OID_sysLocation, location_.c_str());
 }
 
 #ifdef USE_ESP32
-/// @brief Gets PSI RAM size and usage
-/// @param used Pointer to a location where to store used memory value
-/// @return Size of PSI RAM or 0 if not present
 int SNMPComponent::setup_psram_size(int *used) {
   int total_size = 0;
   *used = 0;
-
   size_t free_size = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
   bool available = free_size > 0;
-
   if (available) {
     total_size = heap_caps_get_total_size(MALLOC_CAP_SPIRAM);
     if (total_size > 0) {
       *used = total_size - free_size;
     }
   }
-
   return total_size;
 }
 #endif
 
 void SNMPComponent::setup_storage_mib_() {
-  //  hrStorageIndex
   snmp_agent_.addReadOnlyIntegerHandler(".1.3.6.1.2.1.25.2.3.1.1.1", 1);
-
-  // hrStorageDesc
   snmp_agent_.addReadOnlyStaticStringHandler(".1.3.6.1.2.1.25.2.3.1.3.1", "FLASH");
-
-  // hrAllocationUnit
   snmp_agent_.addReadOnlyIntegerHandler(".1.3.6.1.2.1.25.2.3.1.4.1", 1);
-
-  // hrStorageSize
   snmp_agent_.addDynamicIntegerHandler(".1.3.6.1.2.1.25.2.3.1.5.1",
-                                       []() -> int { return ESP.getFlashChipSize(); });  // NOLINT
-
-  // hrStorageUsed
+                                      []() -> int { return ESP.getFlashChipSize(); });
   snmp_agent_.addDynamicIntegerHandler(".1.3.6.1.2.1.25.2.3.1.6.1",
-                                       []() -> int { return ESP.getSketchSize(); });  // NOLINT
-
-  // SPI RAM
-
-  //  hrStorageIndex
+                                      []() -> int { return ESP.getSketchSize(); });
   snmp_agent_.addReadOnlyIntegerHandler(".1.3.6.1.2.1.25.2.3.1.1.2", 2);
-
-  // hrStorageDesc
   snmp_agent_.addReadOnlyStaticStringHandler(".1.3.6.1.2.1.25.2.3.1.3.2", "SPI RAM");
-
-  // hrAllocationUnit
   snmp_agent_.addReadOnlyIntegerHandler(".1.3.6.1.2.1.25.2.3.1.4.2", 1);
 
 #ifdef USE_ESP32
-  // hrStorageSize
   snmp_agent_.addDynamicIntegerHandler(".1.3.6.1.2.1.25.2.3.1.5.2", []() -> int {
     int u;
     return setup_psram_size(&u);
   });
-
-  // hrStorageUsed
   snmp_agent_.addDynamicIntegerHandler(".1.3.6.1.2.1.25.2.3.1.6.2", []() -> int {
     int u;
     setup_psram_size(&u);
@@ -122,19 +97,13 @@ void SNMPComponent::setup_storage_mib_() {
 #endif
 
 #ifdef USE_ESP8266
-  // hrStorageSize
   snmp_agent_.addReadOnlyIntegerHandler(".1.3.6.1.2.1.25.2.3.1.5.2", 0);
-
-  // hrStorageUsed
   snmp_agent_.addReadOnlyIntegerHandler(".1.3.6.1.2.1.25.2.3.1.6.2", 0);
-
 #endif
 
-  // hrMemorySize [kb]
 #ifdef USE_ESP32
   snmp_agent_.addReadOnlyIntegerHandler(".1.3.6.1.2.1.25.2.2", get_ram_size_kb());
 #endif
-
 #ifdef USE_ESP8266
   snmp_agent_.addReadOnlyIntegerHandler(".1.3.6.1.2.1.25.2.2", 160);
 #endif
@@ -147,135 +116,113 @@ std::string SNMPComponent::get_bssid() {
   return buf;
 }
 
-#if USE_ESP32
+#ifdef USE_ESP32
 void SNMPComponent::setup_esp32_heap_mib_() {
-  // heap size
   snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "32.1.0", []() -> int { return ESP.getHeapSize(); });
-
-  // free heap
   snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "32.2.0", []() -> int { return ESP.getFreeHeap(); });
-
-  // min free heap
   snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "32.3.0", []() -> int { return ESP.getMinFreeHeap(); });
-
-  // max alloc heap
   snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "32.4.0", []() -> int { return ESP.getMaxAllocHeap(); });
 }
 #endif
 
 #ifdef USE_ESP8266
 void SNMPComponent::setup_esp8266_heap_mib_() {
-  snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "8266.1.0", []() -> int { return ESP.getFreeHeap(); });  // NOLINT
-
-  snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "8266.2.0",
-                                       []() -> int { return ESP.getHeapFragmentation(); });  // NOLINT
-
-  snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "8266.3.0",
-                                       []() -> int { return ESP.getMaxFreeBlockSize(); });  // NOLINT
+  snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "8266.1.0", []() -> int { return ESP.getFreeHeap(); });
+  snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "8266.2.0", []() -> int { return ESP.getHeapFragmentation(); });
+  snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "8266.3.0", []() -> int { return ESP.getMaxFreeBlockSize(); });
 }
 #endif
 
 void SNMPComponent::setup_chip_mib_() {
-  // esp32/ esp8266
 #if ESP32
   snmp_agent_.addReadOnlyIntegerHandler(CUSTOM_OID "2.1.0", 32);
 #endif
 #if ESP8266
   snmp_agent_.addReadOnlyIntegerHandler(CUSTOM_OID "2.1.0", 8266);
 #endif
-
-  // CPU clock
-  snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "2.2.0", []() -> int { return ESP.getCpuFreqMHz(); });  // NOLINT
-
-  // chip model
+  snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "2.2.0", []() -> int { return ESP.getCpuFreqMHz(); });
 #if ESP32
   snmp_agent_.addDynamicReadOnlyStringHandler(CUSTOM_OID "2.3.0", []() -> std::string { return ESP.getChipModel(); });
 #endif
 #ifdef USE_ESP8266
   snmp_agent_.addDynamicReadOnlyStringHandler(CUSTOM_OID "2.3.0",
-                                              []() -> std::string { return ESP.getCoreVersion().c_str(); });  // NOLINT
+                                             []() -> std::string { return ESP.getCoreVersion().c_str(); });
 #endif
-
-  // number of cores
 #if USE_ESP32
   snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "2.4.0", []() -> int { return ESP.getChipCores(); });
 #endif
 #if USE_ESP8266
   snmp_agent_.addReadOnlyIntegerHandler(CUSTOM_OID "2.4.0", 1);
 #endif
-
-  // chip id
 #if ESP32
   snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "2.5.0", []() -> int { return ESP.getChipRevision(); });
 #endif
 #if ESP8266
   snmp_agent_.addReadOnlyIntegerHandler(CUSTOM_OID "2.5.0", 0 /*no data for ESP8266*/);
 #endif
-
-
 }
 
 void SNMPComponent::setup_wifi_mib_() {
-  // RSSI
   snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "4.1.0",
-                                       []() -> int { return wifi::global_wifi_component->wifi_rssi(); });
-
-  // BSSID
+                                      []() -> int { return wifi::global_wifi_component->wifi_rssi(); });
   snmp_agent_.addDynamicReadOnlyStringHandler(CUSTOM_OID "4.2.0", get_bssid);
-
-  // SSID
   snmp_agent_.addDynamicReadOnlyStringHandler(CUSTOM_OID "4.3.0",
-                                              []() -> std::string { return wifi::global_wifi_component->wifi_ssid(); });
-
-  // IP
+                                             []() -> std::string { return wifi::global_wifi_component->wifi_ssid(); });
   snmp_agent_.addDynamicReadOnlyStringHandler(
-      CUSTOM_OID "4.4.0", []() -> std::string { 
+      CUSTOM_OID "4.4.0", []() -> std::string {
         const auto& ip_array = wifi::global_wifi_component->wifi_sta_ip_addresses();
-        return ip_array.size() ? wifi::global_wifi_component->wifi_sta_ip_addresses()[0].str() : ""; } );
+        return ip_array.size() ? wifi::global_wifi_component->wifi_sta_ip_addresses()[0].str() : "";
+      });
+}
+
+// ---- NEW: add sensor OIDs ----
+void SNMPComponent::setup_sensor_mib_() {
+  if (temperature_sensor_ != nullptr) {
+    snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "10.1.0", get_temperature);
+  }
+  if (humidity_sensor_ != nullptr) {
+    snmp_agent_.addDynamicIntegerHandler(CUSTOM_OID "10.2.0", get_humidity);
+  }
 }
 
 void SNMPComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SNMP...");
+  snmp_agent_ = SNMPAgent(read_community_.c_str(), write_community_.c_str());
+  snmp_agent_.setUDP(&udp_);
+  snmp_agent_.begin();
 
-  // sysUpTime
-  // this is uptime of network management part of the system
-  // WARNING: Only available if wifi_connected_timestamp() function was implemented
-  // in WiFi module.
-  // By default returns always 0
+  // store singleton instance
+  instance_ = this;
+
   snmp_agent_.addDynamicReadOnlyTimestampHandler(RFC1213_OID_sysUpTime, get_net_uptime);
-
-  // hrSystemUptime
   snmp_agent_.addDynamicReadOnlyTimestampHandler(".1.3.6.1.2.1.25.1.1.0", get_uptime);
 
   setup_system_mib_();
   setup_storage_mib_();
-#if USE_ESP32
+#ifdef USE_ESP32
   setup_esp32_heap_mib_();
 #endif
-#if USE_ESP8266
+#ifdef USE_ESP8266
   setup_esp8266_heap_mib_();
 #endif
   setup_chip_mib_();
   setup_wifi_mib_();
-
-  snmp_agent_.sortHandlers();  // for walk to work properly
-
-  snmp_agent_.setUDP(&udp_);
-  snmp_agent_.begin();
+  setup_sensor_mib_();   // NEW
+  snmp_agent_.sortHandlers();
 }
 
 void SNMPComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "SNMP Config:");
   ESP_LOGCONFIG(TAG, "  Contact: \"%s\"", contact_.c_str());
   ESP_LOGCONFIG(TAG, "  Location: \"%s\"", location_.c_str());
+  ESP_LOGCONFIG(TAG, "  Read Community: \"%s\"", read_community_.c_str());
+  ESP_LOGCONFIG(TAG, "  Write Community: \"%s\"", write_community_.c_str());
 }
 
 void SNMPComponent::loop() { snmp_agent_.loop(); }
 
-#if USE_ESP32
+#ifdef USE_ESP32
 int SNMPComponent::get_ram_size_kb() {
-  // use hardcoded values (number of values in esp_chip_model_t depends on IDF version)
-  // from esp_system.h
   const int chip_esp32 = 1;
   const int chip_esp32_s2 = 2;
   const int chip_esp32_s3 = 9;
@@ -288,24 +235,14 @@ int SNMPComponent::get_ram_size_kb() {
   esp_chip_info(&chip_info);
 
   switch ((int) chip_info.model) {
-    case chip_esp32:
-      return 520;
-
-    case chip_esp32_s2:
-      return 320;
-
-    case chip_esp32_s3:
-      return 512;
-
+    case chip_esp32: return 520;
+    case chip_esp32_s2: return 320;
+    case chip_esp32_s3: return 512;
     case chip_esp32_c2:
     case chip_esp32_c3:
-    case chip_esp32_c6:
-      return 400;
-
-    case chip_esp32_h2:
-      return 256;
+    case chip_esp32_c6: return 400;
+    case chip_esp32_h2: return 256;
   }
-
   return 0;
 }
 #endif

--- a/components/snmp/snmp_component.h
+++ b/components/snmp/snmp_component.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <string>
+#include <memory>
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 #include "SNMP_Agent.h"
-
 #ifdef USE_ESP32
 #include <WiFi.h>
 #include <esp32/himem.h>
@@ -14,44 +14,39 @@
 #include <ESP8266WiFi.h>
 #endif
 #include <WiFiUdp.h>
+#include "esphome/components/sensor/sensor.h"   // NEW
 
 namespace esphome {
 namespace snmp {
 
-/// The SNMP (Simple Network Management Protocol) component provides support for collecting and organizing
-/// information about managed devices on a networks.
-
 class SNMPComponent : public Component {
  public:
-  //SNMPComponent() : snmp_agent_("public", "private"){};
-  //void setup() override;
-  public:
-  void setup() override {
-    // Initialize SNMP with configurable communities
-    SNMP_Agent.begin("ESPHome Device", "ESPHome Location", "ESPHome Description", 0, SNMP_VERSION_2c, this->read_community_.c_str(), this->write_community_.c_str(), SNMP_ENGINE_TIME_SOURCE_NONE);
-    // Rest of the setup code remains the same...
-  }
-
-  // Setter for read community
-  void set_read_community(const std::string &community) { this->read_community_ = community; }
-
-  // Setter for write community
-  void set_write_community(const std::string &community) { this->write_community_ = community; }
-
+  void setup() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
   void loop() override;
 
+  void set_read_community(const std::string &read_community) { read_community_ = read_community; }
+  void set_write_community(const std::string &write_community) { write_community_ = write_community; }
   void set_contact(const std::string &contact) { contact_ = contact; }
-
   void set_location(const std::string &location) { location_ = location; }
+
+  // NEW setters for sensor IDs
+  void set_temperature_sensor(sensor::Sensor *s) { temperature_sensor_ = s; }
+  void set_humidity_sensor(sensor::Sensor *s) { humidity_sensor_ = s; }
 
  protected:
   WiFiUDP udp_;
   SNMPAgent snmp_agent_;
 
-  std::string read_community_ = "public";  // Default value
-  std::string write_community_ = "private";  // Default value
+  std::string read_community_ = "public";
+  std::string write_community_ = "private";
+  std::string contact_;
+  std::string location_;
+
+  // NEW sensor pointers
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
 
   void setup_system_mib_();
   void setup_storage_mib_();
@@ -63,25 +58,24 @@ class SNMPComponent : public Component {
 #endif
   void setup_chip_mib_();
   void setup_wifi_mib_();
+  void setup_sensor_mib_();   // NEW
+
 #ifdef USE_ESP32
   static int setup_psram_size(int *used);
 #endif
 
   static uint32_t get_uptime() { return millis() / 10; }
-
   static uint32_t get_net_uptime();
-
   static std::string get_bssid();
-
 #ifdef USE_ESP32
   static int get_ram_size_kb();
 #endif
 
-  /// contact string
-  std::string contact_;
-
-  /// location string
-  std::string location_;
+  // ---- NEW static helpers for SNMP integer callbacks ----
+ private:
+  static SNMPComponent *instance_;   // singleton pointer
+  static int get_temperature();      // static callback
+  static int get_humidity();         // static callback
 };
 
 }  // namespace snmp

--- a/components/snmp/snmp_component.h
+++ b/components/snmp/snmp_component.h
@@ -23,8 +23,21 @@ namespace snmp {
 
 class SNMPComponent : public Component {
  public:
-  SNMPComponent() : snmp_agent_("public", "private"){};
-  void setup() override;
+  //SNMPComponent() : snmp_agent_("public", "private"){};
+  //void setup() override;
+  public:
+  void setup() override {
+    // Initialize SNMP with configurable communities
+    SNMP_Agent.begin("ESPHome Device", "ESPHome Location", "ESPHome Description", 0, SNMP_VERSION_2c, this->read_community_.c_str(), this->write_community_.c_str(), SNMP_ENGINE_TIME_SOURCE_NONE);
+    // Rest of the setup code remains the same...
+  }
+
+  // Setter for read community
+  void set_read_community(const std::string &community) { this->read_community_ = community; }
+
+  // Setter for write community
+  void set_write_community(const std::string &community) { this->write_community_ = community; }
+
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
   void loop() override;
@@ -36,6 +49,9 @@ class SNMPComponent : public Component {
  protected:
   WiFiUDP udp_;
   SNMPAgent snmp_agent_;
+
+  std::string read_community_ = "public";  // Default value
+  std::string write_community_ = "private";  // Default value
 
   void setup_system_mib_();
   void setup_storage_mib_();


### PR DESCRIPTION
This is an improvement to the original code.
This version add 3 variables that can be used:
1) Community: the new code makes it possible to change the default communities public/private. This can be done using the YAML file on ESPHOME.
2) Temperature and Humidity sensor: it is also possible to use values from 1 sensor and publish them as temperature and humidity using 2 different OIDs. This makes this device a environment sensor.