### PR TITLE
Fix compile error with latest esphome-2026.2.0.

### DIFF
--- a/components/snmp/__init__.py
+++ b/components/snmp/__init__.py
@@ -31,5 +31,7 @@ async def to_code(config):
 
     await cg.register_component(var, config)
 
+    cg.add_library("WiFi", None)
+
     if CORE.is_esp8266 or CORE.is_esp32:
         cg.add_library(r"https://github.com/aquaticus/Arduino_SNMP.git", "2.1.0")


### PR DESCRIPTION
Caused by "Arduino selective compilation":
https://esphome.io/changelog/2026.2.0/#esp32-build-size-and-compile-time-optimizations

```
Compiling .pioenvs/esp32cam-01/src/esphome/components/snmp/snmp_component.cpp.o
In file included from src/esphome/components/snmp/snmp_component.h:6,
                 from src/esphome/components/snmp/snmp_component.cpp:1:
.piolibdeps/esp32cam-01/SNMP_Agent/src/SNMP_Agent.h:13:26: fatal error: WiFiUdp.h: No such file or directory

***********************************************************************
* Looking for WiFiUdp.h dependency? Check our library registry!
*
* CLI  > platformio lib search "header:WiFiUdp.h"
* Web  > https://registry.platformio.org/search?q=header:%1B%5Bm%1B%5BKWiFiUdp.h
*
***********************************************************************

   13 |                 #include <WiFiUdp.h>
      |                          ^~~~~~~~~~~
compilation terminated.
*** [.pioenvs/esp32cam-01/src/esphome/components/snmp/snmp_component.cpp.o] Error 1
========================= [FAILED] Took 166.87 seconds =========================
```