### PR TITLE
Fix compile on 8266

### DIFF
--- a/components/snmp/__init__.py
+++ b/components/snmp/__init__.py
@@ -30,8 +30,9 @@ async def to_code(config):
     cg.add(var.set_contact(config["contact"]))
 
     await cg.register_component(var, config)
-
-    cg.add_library("WiFi", None)
+    
+    if CORE.is_esp32:
+        cg.add_library("WiFi", None)
 
     if CORE.is_esp8266 or CORE.is_esp32:
         cg.add_library(r"https://github.com/aquaticus/Arduino_SNMP.git", "2.1.0")

--- a/components/snmp/__init__.py
+++ b/components/snmp/__init__.py
@@ -31,8 +31,8 @@ async def to_code(config):
 
     await cg.register_component(var, config)
     
-    if CORE.is_esp32:
-        cg.add_library("WiFi", None)
+    #if CORE.is_esp32:
+    #    cg.add_library("WiFi", None)
 
     if CORE.is_esp8266 or CORE.is_esp32:
         cg.add_library(r"https://github.com/aquaticus/Arduino_SNMP.git", "2.1.0")

--- a/components/snmp/__init__.py
+++ b/components/snmp/__init__.py
@@ -30,9 +30,6 @@ async def to_code(config):
     cg.add(var.set_contact(config["contact"]))
 
     await cg.register_component(var, config)
-    
-    #if CORE.is_esp32:
-    #    cg.add_library("WiFi", None)
 
     if CORE.is_esp8266 or CORE.is_esp32:
         cg.add_library(r"https://github.com/aquaticus/Arduino_SNMP.git", "2.1.0")


### PR DESCRIPTION
# Fix failures when compiling `2026.5.0` and `2026.5.1` for ESP-8266
```shell
In file included from .piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:29:
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.h:25: warning: "UDP_TX_PACKET_MAX_SIZE" redefined
   25 | #define UDP_TX_PACKET_MAX_SIZE 24
      |
In file included from .piolibdeps/3rd-f-bathroom-ts/WiFi/src/utility/wifi_drv.h:26,
                 from .piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:26:
/data/cache/platformio/packages/framework-arduinoespressif8266/libraries/ESP8266WiFi/src/WiFiUdp.h:28: note: this is the location of the previous definition
   28 | #define UDP_TX_PACKET_MAX_SIZE 8192
      |
Compiling .pioenvs/3rd-f-bathroom-ts/liba50/WiFi/utility/server_drv.cpp.o
In file included from .piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:29:
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.h:27:7: error: redefinition of 'class WiFiUDP'
   27 | class WiFiUDP : public UDP {
      |       ^~~~~~~
In file included from .piolibdeps/3rd-f-bathroom-ts/WiFi/src/utility/wifi_drv.h:26,
                 from .piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:26:
/data/cache/platformio/packages/framework-arduinoespressif8266/libraries/ESP8266WiFi/src/WiFiUdp.h:32:7: note: previous definition of 'class WiFiUDP'
   32 | class WiFiUDP : public UDP, public SList<WiFiUDP> {
      |       ^~~~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp: In constructor 'WiFiUDP::WiFiUDP()':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:35:22: error: class 'WiFiUDP' does not have any field named '_sock'
   35 | WiFiUDP::WiFiUDP() : _sock(NO_SOCKET_AVAIL) {}
      |                      ^~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp: In member function 'virtual uint8_t WiFiUDP::begin(uint16_t)':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:45:9: error: '_sock' was not declared in this scope; did you mean 'sock'?
   45 |         _sock = sock;
      |         ^~~~~
      |         sock
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:46:9: error: '_port' was not declared in this scope; did you mean 'port'?
   46 |         _port = port;
      |         ^~~~~
      |         port
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp: In member function 'virtual int WiFiUDP::available()':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:56:7: error: '_sock' was not declared in this scope
   56 |   if (_sock != NO_SOCKET_AVAIL)
      |       ^~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp: In member function 'virtual void WiFiUDP::stop()':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:66:8: error: '_sock' was not declared in this scope
   66 |    if (_sock == NO_SOCKET_AVAIL)
      |        ^~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:69:26: error: '_sock' was not declared in this scope
   69 |    ServerDrv::stopClient(_sock);
      |                          ^~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp: In member function 'virtual int WiFiUDP::beginPacket(IPAddress, uint16_t)':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:88:7: error: '_sock' was not declared in this scope
   88 |   if (_sock == NO_SOCKET_AVAIL)
      |       ^~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:90:7: error: '_sock' was not declared in this scope
   90 |   if (_sock != NO_SOCKET_AVAIL)
      |       ^~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp: In member function 'virtual int WiFiUDP::endPacket()':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:101:32: error: '_sock' was not declared in this scope
  101 |  return ServerDrv::sendUdpData(_sock);
      |                                ^~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp: In member function 'virtual size_t WiFiUDP::write(const uint8_t*, size_t)':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:111:27: error: '_sock' was not declared in this scope
  111 |  ServerDrv::insertDataBuf(_sock, buffer, size);
      |                           ^~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp: In member function 'virtual int WiFiUDP::read()':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:125:23: error: '_sock' was not declared in this scope
  125 |    ServerDrv::getData(_sock, &b);
      |                       ^~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp: In member function 'virtual int WiFiUDP::read(unsigned char*, size_t)':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:137:31: error: '_sock' was not declared in this scope
  137 |    if (!ServerDrv::getDataBuf(_sock, buffer, &size))
      |                               ^~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp: In member function 'virtual int WiFiUDP::peek()':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:152:22: error: '_sock' was not declared in this scope
  152 |   ServerDrv::getData(_sock, &b, 1);
      |                      ^~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp: In member function 'virtual IPAddress WiFiUDP::remoteIP()':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:166:25: error: '_sock' was not declared in this scope
  166 |  WiFiDrv::getRemoteData(_sock, _remoteIp, _remotePort);
      |                         ^~~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp: In member function 'virtual uint16_t WiFiUDP::remotePort()':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/WiFiUdp.cpp:176:25: error: '_sock' was not declared in this scope
  176 |  WiFiDrv::getRemoteData(_sock, _remoteIp, _remotePort);
      |                         ^~~~~
Compiling .pioenvs/3rd-f-bathroom-ts/liba50/WiFi/utility/spi_drv.cpp.o
Compiling .pioenvs/3rd-f-bathroom-ts/liba50/WiFi/utility/wifi_drv.cpp.o
*** [.pioenvs/3rd-f-bathroom-ts/liba50/WiFi/WiFiUdp.cpp.o] Error 1
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/utility/spi_drv.cpp:21:10: fatal error: SPI.h: No such file or directory
*************************************************************
* Looking for SPI.h dependency? Check our library registry!
*
* CLI  > platformio lib search "header:SPI.h"
* Web  > https://registry.platformio.org/search?q=header:SPI.h
*
*************************************************************
   21 | #include <SPI.h>
      |          ^~~~~~~
compilation terminated.
*** [.pioenvs/3rd-f-bathroom-ts/liba50/WiFi/utility/spi_drv.cpp.o] Error 1
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/utility/wifi_drv.cpp: In static member function 'static uint8_t WiFiDrv::getEncTypeNetowrks(uint8_t)':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/utility/wifi_drv.cpp:451:10: warning: converting to non-pointer type 'uint8_t' {aka 'unsigned char'} from NULL [-Wconversion-null]
  451 |   return NULL;
      |          ^~~~
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/utility/wifi_drv.cpp: In static member function 'static int32_t WiFiDrv::getRSSINetoworks(uint8_t)':
.piolibdeps/3rd-f-bathroom-ts/WiFi/src/utility/wifi_drv.cpp:476:10: warning: converting to non-pointer type 'int' from NULL [-Wconversion-null]
  476 |   return NULL;
      |          ^~~~
========================= [FAILED] Took 46.99 seconds =========================
```
# The Fix
Let PlatformIO handle the wifi library using the existing 
```python 
DEPENDENCIES = ["wifi"]
```
 by removing
```python
cg.add_library("WiFi", None)
```

# Test it

```yaml
external_components:
    - source: 
        type: git
        url: https://github.com/JacobErnst98/esphome-snmp
        ref: 8266-fix
```