### PR TITLE
Fix ESP-32 Compile on 2026.5.1

### DIFF
--- a/components/snmp/__init__.py
+++ b/components/snmp/__init__.py
@@ -31,5 +31,8 @@ async def to_code(config):
 
     await cg.register_component(var, config)
 
+    if CORE.is_esp32:
+       cg.add_library("WiFi", None)
+
     if CORE.is_esp8266 or CORE.is_esp32:
         cg.add_library(r"https://github.com/aquaticus/Arduino_SNMP.git", "2.1.0")


### PR DESCRIPTION
Apparently I did not do a clear the build cache before trying the ESP-32 build of my last PR 😅...

This adds back the
```cpp
cg.add_library("WiFi", None)
```
but adds
```cpp
if CORE.is_esp32:
```
To prevent the 8266 lib conflict.


# Yaml to test PR:
```yaml
external_components:
    # SNMP component
    - source: 
        url: https://github.com/JacobErnst98/esphome-snmp
        type: git
        ref: 2026-5-1_32-fix
```